### PR TITLE
Fix EPERM issue when burning in Windows

### DIFF
--- a/build/browser/app.js
+++ b/build/browser/app.js
@@ -69,6 +69,11 @@ app.controller('AppController', function($q, DriveScannerService, SelectionState
   };
 
   this.burn = function(image, drive) {
+
+    // Stop scanning drives when burning
+    // otherwise Windows throws EPERM
+    self.scanner.stop();
+
     console.debug('Burning ' + image + ' to ' + drive);
     return self.writer.burn(image, drive).then(function() {
       console.debug('Done!');

--- a/lib/browser/app.js
+++ b/lib/browser/app.js
@@ -68,6 +68,11 @@ app.controller('AppController', function($q, DriveScannerService, SelectionState
   };
 
   this.burn = function(image, drive) {
+
+    // Stop scanning drives when burning
+    // otherwise Windows throws EPERM
+    self.scanner.stop();
+
     console.debug('Burning ' + image + ' to ' + drive);
     return self.writer.burn(image, drive).then(function() {
       console.debug('Done!');


### PR DESCRIPTION
The issue is fixed by stopping the drive scanner interval before
burning.