### PR TITLE
Upgrade sudo-prompt to v1.1.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "is-elevated": "^1.0.0",
     "lodash": "^3.10.1",
     "resin-image-write": "^2.0.5",
-    "sudo-prompt": "^1.1.7",
+    "sudo-prompt": "^1.1.8",
     "umount": "^1.1.1",
     "windosu": "^0.1.3"
   },


### PR DESCRIPTION
This version contains a fix that allows Herostratus to be correctly
elevated when running with `npm start`.

See fix here:
https://github.com/jorangreef/sudo-prompt/commit/344da8f7b2325460f19353ff2dbcf59f92a89426