### PR TITLE
Downgrade to Electron v0.31.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "browserify": "^12.0.1",
     "electron-mocha": "^0.5.0",
     "electron-packager": "^5.1.1",
-    "electron-prebuilt": "^0.33.0",
+    "electron-prebuilt": "^0.31.2",
     "gulp": "^3.9.0",
     "gulp-jshint": "^1.11.2",
     "gulp-sass": "^2.0.4",


### PR DESCRIPTION
This version is the last one that works on GNU/Linux.