### PR TITLE
Package Electron with 0.31.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 ELECTRON_PACKAGER=./node_modules/.bin/electron-packager
 ELECTRON_IGNORE=$(shell cat package.ignore | tr "\\n" "|" | sed "s/.$$//")
-ELECTRON_VERSION=0.34.2
+ELECTRON_VERSION=0.31.2
 
 release/Herostratus-darwin-x64: .
 	$(ELECTRON_PACKAGER) . Herostratus \


### PR DESCRIPTION
This was the last known version to work on Ubuntu.

See https://github.com/resin-io/herostratus/pull/10