### PR TITLE
Fire and forget OS X sudo prompt

### DIFF
--- a/lib/elevate.js
+++ b/lib/elevate.js
@@ -45,15 +45,10 @@ exports.require = function(callback) {
 
       if (platform === 'darwin') {
         sudoPrompt.setName('Herostratus');
-        sudoPrompt.exec(process.argv.join(' '), function(error) {
-          if (error) {
-            console.error(error.message);
-            process.exit(1);
-          }
-
-          // Don't keep the original parent process alive
+        sudoPrompt.exec(process.argv.join(' '));
+        setTimeout(function() {
           process.exit(0);
-        });
+        }, 300);
       }
       else if (platform === 'win32') {
         var command = _.map(process.argv, function(word) {


### PR DESCRIPTION
Currently, the parent application will not be closed until the children
process is closed, leading to two Herostratus applications running at
the same time on OS X.