### PR TITLE
osx(package) Build without --asar

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,6 @@ release/Herostratus-darwin-x64: .
 		--arch=x64 \
 		--version=$(ELECTRON_VERSION) \
 		--ignore="$(ELECTRON_IGNORE)" \
-		--asar \
 		--icon="assets/icon.icns" \
 		--overwrite \
 		--out=release/


### PR DESCRIPTION
This change fixes the following issues:

- https://github.com/resin-io/herostratus/issues/17
- https://github.com/resin-io/herostratus/issues/18