### PR TITLE
osx: Fix first time elevation failure

### DIFF
--- a/lib/elevate.js
+++ b/lib/elevate.js
@@ -29,7 +29,7 @@ var windosu = require('windosu');
 var os = require('os');
 var platform = os.platform();
 
-exports.require = function(callback) {
+exports.require = function(app, callback) {
   'use strict';
 
   isElevated(function(error, elevated) {
@@ -44,11 +44,21 @@ exports.require = function(callback) {
     if (!elevated) {
 
       if (platform === 'darwin') {
-        sudoPrompt.setName('Herostratus');
-        sudoPrompt.exec(process.argv.join(' '));
-        setTimeout(function() {
+
+        // Keep parent process hidden
+        app.dock.hide();
+
+        sudoPrompt.exec(process.argv.join(' '), {
+          name: 'Herostratus'
+        }, function(error) {
+          if (error) {
+            console.error(error.message);
+            process.exit(1);
+          }
+
+          // Don't keep the original parent process alive
           process.exit(0);
-        }, 500);
+        });
       }
       else if (platform === 'win32') {
         var command = _.map(process.argv, function(word) {

--- a/lib/herostratus.js
+++ b/lib/herostratus.js
@@ -35,7 +35,7 @@ app.on('ready', function() {
   // No menu bar
   Menu.setApplicationMenu(null);
 
-  elevate.require(function(error) {
+  elevate.require(app, function(error) {
 
     if (error) {
       throw error;

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "is-elevated": "^1.0.0",
     "lodash": "^3.10.1",
     "resin-image-write": "^2.0.5",
-    "sudo-prompt": "^1.1.8",
+    "sudo-prompt": "^2.0.2",
     "umount": "^1.1.1",
     "windosu": "^0.1.3"
   },


### PR DESCRIPTION
Currently we fire and forget `sudoPrompt.exec()` and run a timeout for
`process.exit(0)` right away, however this means that the timeout will
start as soon as the elevation dialog is shown when no sudo cache exists
and therefore the timeout will finish before the user can type his
password and submit.

The fix is to keep the parent alive until the children dies, but call
`app.dock.hide()` to make the parent completely invisible to the
operating system.

Fixes: https://github.com/resin-io/herostratus/issues/31