### PR TITLE
win32: Show drive letter instead of device in dropdown

### DIFF
--- a/build/browser/app.js
+++ b/build/browser/app.js
@@ -68,6 +68,8 @@ app.controller('AppController', function($q, DriveScannerService, SelectionState
     console.debug('Drive selected: ' + drive);
   };
 
+  this.platform = window.process.platform;
+
   this.burn = function(image, drive) {
 
     // Stop scanning drives when burning

--- a/lib/browser/app.js
+++ b/lib/browser/app.js
@@ -67,6 +67,8 @@ app.controller('AppController', function($q, DriveScannerService, SelectionState
     console.debug('Drive selected: ' + drive);
   };
 
+  this.platform = window.process.platform;
+
   this.burn = function(image, drive) {
 
     // Stop scanning drives when burning

--- a/lib/index.html
+++ b/lib/index.html
@@ -54,7 +54,13 @@
 
                       <ul class="dropdown-menu">
                         <li ng-repeat="drive in app.scanner.drives">
-                          <a href="#" ng-click="app.selectDrive(drive.device)">{{ drive.device }} - {{ drive.size }}</a>
+                          <a href="#" ng-click="app.selectDrive(drive.device)">
+
+                            <!-- Show drive letter instead of phsycal drive name on Windows -->
+                            <span ng-if="app.platform == 'win32'">Drive {{ drive.mountpoint }}\ - {{ drive.size }}</span>
+                            <span ng-if="app.platform != 'win32'">{{ drive.device }} - {{ drive.size }}</span>
+
+                          </a>
                         </li>
                       </ul>
                     </div>


### PR DESCRIPTION
Physical drive names are long and cause the dropdowns to overflow.

Fixes: https://github.com/resin-io/herostratus/issues/23