### PR TITLE
Upgrade windosu to v0.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "resin-image-write": "^2.0.5",
     "sudo-prompt": "^2.0.2",
     "umount": "^1.1.1",
-    "windosu": "^0.1.3"
+    "windosu": "^0.2.0"
   },
   "devDependencies": {
     "angular-mocks": "^1.4.7",


### PR DESCRIPTION
This version contains a fix for a cmd.exe window popping in for a
fraction of a second when elevating Herostratus on Windows.

Fixes: https://github.com/resin-io/herostratus/issues/39