### PR TITLE
Fix drivelist spawn issues inside asar package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 ELECTRON_PACKAGER=./node_modules/.bin/electron-packager
 ELECTRON_IGNORE=$(shell cat package.ignore | tr "\\n" "|" | sed "s/.$$//")
-ELECTRON_VERSION=0.31.2
+ELECTRON_VERSION=0.35.2
 
 release/Herostratus-darwin-x64: .
 	$(ELECTRON_PACKAGER) . Herostratus \
@@ -8,6 +8,7 @@ release/Herostratus-darwin-x64: .
 		--arch=x64 \
 		--version=$(ELECTRON_VERSION) \
 		--ignore="$(ELECTRON_IGNORE)" \
+		--asar \
 		--icon="assets/icon.icns" \
 		--overwrite \
 		--out=release/

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "angular-ui-bootstrap": "^0.14.2",
     "bluebird": "^3.0.5",
     "bootstrap-sass": "^3.3.5",
-    "drivelist": "^2.0.0",
+    "drivelist": "^2.0.4",
     "electron-window": "^0.6.0",
     "flexboxgrid": "^6.3.0",
     "is-elevated": "^1.0.0",


### PR DESCRIPTION
The following libraries were upgraded to versions that include this fix:

- electron-prebuilt
- drivelist

Fixes: https://github.com/resin-io/herostratus/issues/35
Fixes: https://github.com/resin-io/herostratus/issues/18