### PR TITLE
Fix Windows not asking for elevation when packaged

### DIFF
--- a/package.ignore
+++ b/package.ignore
@@ -1,7 +1,7 @@
 LICENSE
 Makefile
 package.ignore
-(.*).md
+(.*)\.md
 appveyor.yml
 bower.json
 gulpfile.js


### PR DESCRIPTION
The issue is that the `windosu-elevate.cmd` script that `windosu`
internally calls to perform the elevation.

After some investigation this is due one of our ignore regular
expressions used to filter out unnecessary files from the production
package:

```
(.*).md
```

The period matches anything but a space, causing file ending in `cmd` to
be matched, and therefore excluded from the package.

Since the intention of this regex was to match a literal period,
escaping does the trick.

Partly-Fixes: https://github.com/resin-io/herostratus/issues/20