### PR TITLE
Prevent flash of unstyled content at startup

### DIFF
--- a/build/browser/app.js
+++ b/build/browser/app.js
@@ -64,6 +64,9 @@ app.controller('AppController', function($q, DriveScannerService, SelectionState
 
   this.restart();
 
+  // We're ready to unhide the application now
+  document.querySelector('body').style.display = 'initial';
+
   this.selectImage = function() {
     return $q.when(dialog.selectImage()).then(function(image) {
       self.selection.setImage(image);

--- a/build/css/main.css
+++ b/build/css/main.css
@@ -5938,6 +5938,9 @@ body {
 .space-right-tiny {
   margin-right: 5px; }
 
+html {
+  background-color: #535760; }
+
 hero-badge .badge {
   background-color: #535760; }
 

--- a/lib/browser/app.js
+++ b/lib/browser/app.js
@@ -63,6 +63,9 @@ app.controller('AppController', function($q, DriveScannerService, SelectionState
 
   this.restart();
 
+  // We're ready to unhide the application now
+  document.querySelector('body').style.display = 'initial';
+
   this.selectImage = function() {
     return $q.when(dialog.selectImage()).then(function(image) {
       self.selection.setImage(image);

--- a/lib/index.html
+++ b/lib/index.html
@@ -3,7 +3,6 @@
   <head>
     <title>Herostratus</title>
     <link rel="stylesheet" type="text/css" href="../node_modules/flexboxgrid/dist/flexboxgrid.css">
-    <link rel="stylesheet" type="text/css" href="../node_modules/angular/angular-csp.css">
     <link rel="stylesheet" type="text/css" href="../build/css/main.css">
 
     <link rel="import" href="components/hero-badge.html">
@@ -15,7 +14,7 @@
 
     <script src="../build/browser/app.js"></script>
   </head>
-  <body ng-app="Herostratus" ng-controller="AppController as app" ng-cloak>
+  <body ng-app="Herostratus" ng-controller="AppController as app" style="display: none">
 
     <div class="content row middle-xs space-horizontal-large">
       <div class="col-xs">

--- a/lib/index.html
+++ b/lib/index.html
@@ -31,7 +31,7 @@
                   <hero-button ng-click="app.selectImage()">Select image</hero-button>
                 </div>
                 <div ng-show="app.selection.hasImage()">
-                  <span>{{ app.selection.getImage() | basename }}</span>
+                  <span ng-bind="app.selection.getImage() | basename"></span>
                 </div>
               </div>
             </div>
@@ -58,8 +58,10 @@
                           <a href="#" ng-click="app.selectDrive(drive)">
 
                             <!-- Show drive letter instead of phsycal drive name on Windows -->
-                            <span ng-if="app.platform == 'win32'">Drive {{ drive.mountpoint }}\ - {{ drive.size }}</span>
-                            <span ng-if="app.platform != 'win32'">{{ drive.device }} - {{ drive.size }}</span>
+                            <span ng-if="app.platform == 'win32'"
+                              ng-bind="'Drive ' + drive.mountpoint + '\\ - ' + drive.size"></span>
+                            <span ng-if="app.platform != 'win32'"
+                              ng-bind="drive.device + ' - ' + drive.size"></span>
 
                           </a>
                         </li>
@@ -73,7 +75,7 @@
 
                 </div>
                 <div ng-show="app.selection.hasDrive()">
-                  <span>{{ app.selection.getDrive().device }}</span>
+                  <span ng-bind="app.selection.getDrive().device"></span>
                 </div>
               </div>
             </div>
@@ -91,7 +93,8 @@
                     <span ng-show="app.writer.progress == 100 && app.writer.isBurning()">Finishing...</span>
                     <span ng-show="app.writer.progress == 0 && !app.writer.isBurning()">Burn!</span>
                     <span ng-show="app.writer.progress == 0 && app.writer.isBurning()">Starting...</span>
-                    <span ng-show="app.writer.progress != 0 && app.writer.progress != 100">{{ app.writer.progress }}%</span>
+                    <span ng-show="app.writer.progress != 0 && app.writer.progress != 100"
+                      ng-bind="app.writer.progress + '%'"></span>
                 </hero-progress-button>
               </div>
             </div>

--- a/lib/scss/main.scss
+++ b/lib/scss/main.scss
@@ -39,6 +39,11 @@ $btn-padding: 10px;
 
 @import "./modules/space";
 
+// Prevent white flash when running application
+html {
+  background-color: $body-bg;
+}
+
 hero-badge .badge {
   background-color: $body-bg;
 }


### PR DESCRIPTION
This PR includes various improvements:

- Prevent white flash when running application
- Implement poor man's ngCloak based on app controller
- Use ngBind instead of curly braces interpolation

Fixes: https://github.com/resin-io/herostratus/issues/62