### PR TITLE
Replace windosu with elevator

### DIFF
--- a/lib/elevate.js
+++ b/lib/elevate.js
@@ -25,7 +25,6 @@ var _ = require('lodash');
 var dialog = require('dialog');
 var isElevated = require('is-elevated');
 var sudoPrompt = require('sudo-prompt');
-var windosu = require('windosu');
 var os = require('os');
 var platform = os.platform();
 
@@ -61,11 +60,9 @@ exports.require = function(app, callback) {
         });
       }
       else if (platform === 'win32') {
-        var command = _.map(process.argv, function(word) {
-          return '"' + word + '"';
-        });
+        var elevator = require('elevator');
 
-        windosu.exec(command.join(' '), null, function(error) {
+        elevator.execute(process.argv, {}, function(error) {
           if (error) {
             console.error(error.message);
             process.exit(1);

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "author": "Juan Cruz Viotti <juan@resin.io>",
   "license": "MIT",
   "optionalDependencies": {
+    "elevator": "^1.0.0",
     "removedrive": "^1.0.0"
   },
   "dependencies": {
@@ -31,8 +32,7 @@
     "lodash": "^3.10.1",
     "resin-image-write": "^2.0.5",
     "sudo-prompt": "^2.0.2",
-    "umount": "^1.1.1",
-    "windosu": "^0.2.0"
+    "umount": "^1.1.1"
   },
   "devDependencies": {
     "angular-mocks": "^1.4.7",


### PR DESCRIPTION
For some reason, when using `windosu`, the app is elevated three times.
However this only happens when the application is packaged for
distribution.

After a couple of days debugging this issue, we have no clue about
what's going on, but `elevator` seems to work fine.

Fixes: https://github.com/resin-io/herostratus/issues/29