### PR TITLE
Show drive letter on selection on Windows

### DIFF
--- a/lib/index.html
+++ b/lib/index.html
@@ -74,7 +74,8 @@
 
                 </div>
                 <div ng-show="app.selection.hasDrive()">
-                  <span ng-bind="app.selection.getDrive().device"></span>
+                  <span ng-if="app.platform == 'win32'" ng-bind="app.selection.getDrive().mountpoint + '\\'"></span>
+                  <span ng-if="app.platform != 'win32'" ng-bind="app.selection.getDrive().device"></span>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
Showing `\\.\PhysicalDriveN` makes no sense for a Windows user after
selecting based on drive letters on the dropdown.